### PR TITLE
Exception handling

### DIFF
--- a/ntbk/initialize.py
+++ b/ntbk/initialize.py
@@ -17,16 +17,16 @@ def init_config_file(config):
     if not config.config_file_exists():
         config.reset_to_defaults()
 
-        if not config.get('ntbk_dir'):
-            ntbk_dir = input('Enter notebook save directory (default = ~/ntbk): ') or '~/ntbk'
-            config.set('ntbk_dir', ntbk_dir)
+    if not config.get('ntbk_dir'):
+        ntbk_dir = input('Enter notebook save directory (default = ~/ntbk): ') or '~/ntbk'
+        config.set('ntbk_dir', ntbk_dir)
 
-        if not config.get('editor'):
-            editor = input('Editor (will fallback to $EDITOR, '\
-                'then finally vim if not specified): ')\
-                or (os.environ['EDITOR'] if 'EDITOR' in os.environ else 'vim')
+    if not config.get('editor'):
+        editor = input('Editor (will fallback to $EDITOR, '\
+            'then finally vim if not specified): ')\
+            or (os.environ['EDITOR'] if 'EDITOR' in os.environ else 'vim')
 
-            config.set('editor', editor)
+        config.set('editor', editor)
 
     if not config.is_valid():
         raise InvalidConfigException()

--- a/ntbk/main.py
+++ b/ntbk/main.py
@@ -30,7 +30,7 @@ def run():
         exit_with_err(err)
     except KeyboardInterrupt:
         sys.exit(0)
-    except Exception as err:
+    except Exception as err: #pylint: disable=broad-except
         exit_with_err(err)
 
 if __name__ == '__main__':

--- a/ntbk/main.py
+++ b/ntbk/main.py
@@ -13,6 +13,11 @@ from ntbk.dispatcher import Dispatcher
 from ntbk.filesystem import Filesystem
 from ntbk.exceptions import InvalidConfigException
 
+def exit_with_err(err):
+    """Print the error and exit the application"""
+    print(err, file=sys.stderr)
+    sys.exit(1)
+
 def run():
     """Run the application"""
     try:
@@ -22,8 +27,9 @@ def run():
         initialize.init_app(config)
         Dispatcher(config, filesystem).run(sys.argv[1:])
     except InvalidConfigException as err:
-        print(err, file=sys.stderr)
-        sys.exit(1)
+        exit_with_err(err)
+    except KeyboardInterrupt:
+        sys.exit(0)
 
 if __name__ == '__main__':
     run()

--- a/ntbk/main.py
+++ b/ntbk/main.py
@@ -30,6 +30,8 @@ def run():
         exit_with_err(err)
     except KeyboardInterrupt:
         sys.exit(0)
+    except Exception as err:
+        exit_with_err(err)
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
Catch KeyboardInterrupt and exit quietly. Catch all other exceptions and print the error and exit with status 1. 

Closes #52 
Closes #53 