### PR TITLE
Sort commands that output lists

### DIFF
--- a/ntbk/dispatcher.py
+++ b/ntbk/dispatcher.py
@@ -86,12 +86,12 @@ class Dispatcher():
         self.filesystem.open_file_in_editor(entity.get_path())
 
     def list_entities(self, entities): #pylint: disable=no-self-use
-        """Takes a list of LogFile or CollectionFile objects and prints out their names
+        """Takes a list of LogFile or CollectionFile objects and prints out their names, sorted a-z
 
         Arguments:
             entities - List of LogFile and/or CollectionFile objects
         """
-        for entity in entities:
+        for entity in sorted(entities, key=lambda e: e.get_name().lower()):
             print(entity.get_name())
 
     def handle_logfile_command(self, args):

--- a/ntbk/entities/collections.py
+++ b/ntbk/entities/collections.py
@@ -135,6 +135,7 @@ def get_all_collections(config, filesystem):
         config - Config instance
         filesystem - Filesystem instance
     """
-    return [Collection(config, filesystem, child.stem)
+    collections = [Collection(config, filesystem, child.stem)
         for child in filesystem.get_collection_base_path().glob('*/')]
-        
+
+    return sorted(collections, key=lambda col: col.get_name().lower())

--- a/ntbk/entities/templates.py
+++ b/ntbk/entities/templates.py
@@ -89,5 +89,7 @@ class Template():
 
 def get_all_templates(config, filesystem):
     """Get a list of Template objects for all templates in the notebook"""
-    return [Template(config, filesystem, child.stem)
+    templates = [Template(config, filesystem, child.stem)
         for child in filesystem.get_templates_base_path().glob('*.md')]
+
+    return sorted(templates, key=lambda template: template.get_name().lower())

--- a/tests/feature/test_listing.py
+++ b/tests/feature/test_listing.py
@@ -13,7 +13,8 @@ def test_listing_templates(dispatcher, filesystem, mocker):
 
     dispatcher.run(['templates'])
 
-    print.assert_has_calls([call('template_one'), call('template_two')], any_order=True)
+    # With any_order=False we make sure they are printed in this order too
+    print.assert_has_calls([call('template_one'), call('template_two')], any_order=False)
 
 def test_listing_collections(dispatcher, filesystem, mocker):
     """Test 'collections' command lists all collections"""
@@ -29,10 +30,12 @@ def test_listing_collections(dispatcher, filesystem, mocker):
     for alias in aliases:
         dispatcher.run([alias])
 
+        # With any_order=False we make sure they are printed in this order too
         print.assert_has_calls([
             call(f'books {Fore.BLUE}[1 file]{Style.RESET_ALL}'),
             call(f'recipes {Fore.GREEN}[2 files]{Style.RESET_ALL}')],
-            any_order=True)
+            any_order=False)
+
         print.reset_mock()
 
 @freeze_time("2020-01-01")
@@ -47,7 +50,8 @@ def test_listing_log_files_for_day(dispatcher, filesystem, mocker):
 
     dispatcher.run(['today', '--list'])
 
-    print.assert_has_calls([call('index'), call('work')], any_order=True)
+    # With any_order=False we make sure they are printed in this order too
+    print.assert_has_calls([call('index'), call('work')], any_order=False)
 
 def test_listing_collection_files(dispatcher, filesystem, mocker):
     """test --list flag on collection lists all collection files"""
@@ -57,7 +61,9 @@ def test_listing_collection_files(dispatcher, filesystem, mocker):
     col_path.mkdir(parents=True)
     (col_path / 'montana.md').touch()
     (col_path / 'utah.md').touch()
+    (col_path / 'alaska.md').touch()
 
     dispatcher.run(['collection', 'travel', '--list'])
 
-    print.assert_has_calls([call('montana'), call('utah')], any_order=True)
+    # With any_order=False we make sure they are printed in this order too
+    print.assert_has_calls([call('alaska'), call('montana'), call('utah')], any_order=False)


### PR DESCRIPTION
Sorts the output of:

- `--list` (both collections and logs)
- `cols`
- `templates`

Closes #58